### PR TITLE
Revert "build(deps): Bump markdig from 0.20.0 to 0.26.0 in /tools/docfx"

### DIFF
--- a/tools/docfx/Roadmap.DotFX.csproj
+++ b/tools/docfx/Roadmap.DotFX.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="2.0.9" />
-    <PackageReference Include="markdig" Version="0.26.0" />
+    <PackageReference Include="markdig" Version="0.20.0" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="Microsoft.DocAsCode.Common" Version="2.58.4" />
     <PackageReference Include="Microsoft.DocAsCode.Plugins" Version="2.58.4" />


### PR DESCRIPTION
Reverts SierraSoftworks/roadmap#51