### PR TITLE
Add support for objectives into the example in the readme.md at root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ timeline:
     title: Project Start
     description: This is when we will start working on the project, get the team ready!
 
+objectives:
+  - title: Market Dominance
+    description: |
+      Provide actionable analytics drawn from big data to improve our brand identity in
+      the advertainment sector, maximizing clickbait and establishing ourselves as a disruptor
+      in this industry.
+
 milestones:
   - id: team
     title: Build the Team


### PR DESCRIPTION
I noticed support for Objectives was added in commit https://github.com/SierraSoftworks/roadmap/commit/103d2437c318766310046bcaaaefaa5385f03848 but the example doc (or schema?) in the `README.md` at the root, which is what people read first hasn't been updated with this support.

I don't know if you want to have the schema or example in the readme be more dynamic but I figured a start is to put the section in there to show all the users of this tool it exists.