### PR TITLE
fix: import js-yaml as a namespace to fix the docs build

### DIFF
--- a/docs/.vuepress/components/GitHubRepoViewer.vue
+++ b/docs/.vuepress/components/GitHubRepoViewer.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import { defineComponent, computed, ref, watch } from "vue";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 export default defineComponent({
   setup() {


### PR DESCRIPTION
The **Documentation** workflow has been failing on `main` since at least July 2nd with:

```
[MISSING_EXPORT] "default" is not exported by "node_modules/js-yaml/dist/js-yaml.mjs"
```

The js-yaml v5 upgrade (Dependabot) removed the default export from the package's ESM build, breaking `import yaml from "js-yaml"` in `docs/.vuepress/components/GitHubRepoViewer.vue`. This switches to a namespace import (`import * as yaml from "js-yaml"`), which works with the named `load`/`JSON_SCHEMA` exports the component uses.

Verified locally: `npm ci && npm run build` in `docs/` now completes successfully.

Note: this also unblocks deployment of the analytics migration merged in #745, since the docs site can't rebuild while this workflow is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWwFpShoYkDFjkKUYQnn45)_